### PR TITLE
Remove unused XHR code

### DIFF
--- a/backend/app/controllers/spree/admin/users_controller.rb
+++ b/backend/app/controllers/spree/admin/users_controller.rb
@@ -123,21 +123,11 @@ module Spree
 
       def collection
         return @collection if @collection
-        if request.xhr? && params[:q].present?
-          @collection = Spree.user_class.includes(:bill_address, :ship_address)
-                            .where("#{Spree.user_class.table_name}.email #{LIKE} :search
-                                   OR (spree_addresses.firstname #{LIKE} :search AND spree_addresses.id = #{Spree.user_class.table_name}.bill_address_id)
-                                   OR (spree_addresses.lastname  #{LIKE} :search AND spree_addresses.id = #{Spree.user_class.table_name}.bill_address_id)
-                                   OR (spree_addresses.firstname #{LIKE} :search AND spree_addresses.id = #{Spree.user_class.table_name}.ship_address_id)
-                                   OR (spree_addresses.lastname  #{LIKE} :search AND spree_addresses.id = #{Spree.user_class.table_name}.ship_address_id)",
-                                  { search: "#{params[:q].strip}%" })
-                            .limit(params[:limit] || 100)
-        else
-          @search = Spree.user_class.ransack(params[:q])
-          @collection = @search.result.includes(:spree_roles)
-          @collection = @collection.includes(:spree_orders)
-          @collection = @collection.page(params[:page]).per(Spree::Config[:admin_products_per_page])
-        end
+
+        @search = Spree.user_class.ransack(params[:q])
+        @collection = @search.result.includes(:spree_roles)
+        @collection = @collection.includes(:spree_orders)
+        @collection = @collection.page(params[:page]).per(Spree::Config[:admin_products_per_page])
       end
 
       def user_params


### PR DESCRIPTION
**Description**
It appears unused. If it is/was, it fails with `uninitialized constant Spree::Admin::UsersController::LIKE`. The constant was removed in https://github.com/halilim/solidus/commit/fe77e9cc095b1fb41040270ef697391cb8a5daef but it looks like there was another place after all :)

**Checklist:**
- [x] I have followed [Pull Request guidelines](https://github.com/solidusio/solidus/blob/master/CONTRIBUTING.md#pull-request-guidelines)
- [x] I have added a detailed description into each commit message
- [x] I have updated Guides and README accordingly to this change (if needed)
- [x] I have added tests to cover this change (if needed)
- [x] I have attached screenshots to this PR for visual changes (if needed)
